### PR TITLE
Pass std instead of variance as `gain` to comply with TF 1.13

### DIFF
--- a/Delta_Orthogonal_Convolution_Demo.ipynb
+++ b/Delta_Orthogonal_Convolution_Demo.ipynb
@@ -381,7 +381,7 @@
         "  for j in range(DEPTH):\n",
         "    name = 'block_conv_{}'.format(j)\n",
         "    kernel_name, bias_name = name + 'kernel', name + 'bias'\n",
-        "    kernel = get_orthogonal_weight(kernel_name, shape, gain=W_VAR)\n",
+        "    kernel = get_orthogonal_weight(kernel_name, shape, gain=std)\n",
         "    bias = get_weight([C_SIZE], std=np.sqrt(B_VAR), name=bias_name)\n",
         "    z_pad = circular_padding(z, new_width, K_SIZE)\n",
         "    h = conv2d(z_pad, kernel, padding='VALID') + bias\n",


### PR DESCRIPTION
See behavioral changes: https://github.com/tensorflow/tensorflow/releases/tag/v1.13.0-rc0